### PR TITLE
feat: updated BlockStore sample

### DIFF
--- a/BlockStore/app/build.gradle
+++ b/BlockStore/app/build.gradle
@@ -56,12 +56,13 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'com.google.android.gms:play-services-auth-blockstore:16.0.2'
+    implementation 'com.google.android.gms:play-services-auth-blockstore:16.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     implementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'
+    implementation 'androidx.work:work-runtime-ktx:2.7.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/BlockStore/app/src/main/java/com/google/android/gms/identity/sample/blockstore/BlockStoreRepository.kt
+++ b/BlockStore/app/src/main/java/com/google/android/gms/identity/sample/blockstore/BlockStoreRepository.kt
@@ -1,7 +1,8 @@
 package com.google.android.gms.identity.sample.blockstore
 
-import com.google.android.gms.auth.blockstore.BlockstoreClient
-import com.google.android.gms.auth.blockstore.StoreBytesData
+import android.content.ContentValues
+import android.util.Log
+import com.google.android.gms.auth.blockstore.*
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -12,21 +13,55 @@ import javax.inject.Inject
 class BlockStoreRepository @Inject constructor(
     private val blockStoreClient: BlockstoreClient
 ) {
+    private val key = BlockstoreClient.DEFAULT_BYTES_DATA_KEY
 
     // This function saves the authentication token to Block Store.
     suspend fun storeBytes(inputString: String) {
-        val data: StoreBytesData =
-            StoreBytesData.Builder().setBytes(inputString.toByteArray()).build()
-        blockStoreClient.storeBytes(data).await()
+        val storeRequest: StoreBytesData = StoreBytesData.Builder()
+            .setBytes(inputString.toByteArray())
+            .setKey(key)
+            .build()
+
+        blockStoreClient.storeBytes(storeRequest)
+            .addOnSuccessListener { result: Int ->
+                Log.d(ContentValues.TAG, "Stored $result bytes")
+            }.addOnFailureListener { e ->
+                Log.e(ContentValues.TAG, "Failed to store bytes", e)
+            }.await()
     }
 
     // This function retrieves your Block Store data.
     suspend fun retrieveBytes(): String {
-        return String(blockStoreClient.retrieveBytes().await())
+        var bytes = ""
+        val requestedKeys = listOf(key)
+        val retrieveRequest = RetrieveBytesRequest
+            .Builder()
+            .setKeys(requestedKeys)
+            .build()
+
+        blockStoreClient.retrieveBytes(retrieveRequest)
+            .addOnSuccessListener { result: RetrieveBytesResponse ->
+                val blockstoreDataMap = result.blockstoreDataMap
+                for ((key, value) in blockstoreDataMap) {
+                    Log.d(ContentValues.TAG, String.format("Retrieved bytes %s associated with key %s.", String(value.bytes), key))
+                    bytes = String(value.bytes)
+                }
+            }
+            .addOnFailureListener { e: Exception? ->
+                Log.e(ContentValues.TAG, "Failed to store bytes", e)
+            }.await()
+
+        return bytes
     }
 
     // This function clears your Block Store data.
     suspend fun clearBytes() {
-        storeBytes("")
+        val requestedKeys = listOf(key)
+        val retrieveRequest = DeleteBytesRequest.Builder().setKeys(requestedKeys).build()
+
+        blockStoreClient.deleteBytes(retrieveRequest)
+            .addOnSuccessListener { result: Boolean ->
+                Log.d(ContentValues.TAG, "Any data found and deleted? $result")
+            }.await()
     }
 }

--- a/BlockStore/build.gradle
+++ b/BlockStore/build.gradle
@@ -15,15 +15,15 @@
  */
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.21"
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/BlockStore/gradle/wrapper/gradle-wrapper.properties
+++ b/BlockStore/gradle/wrapper/gradle-wrapper.properties
@@ -14,7 +14,7 @@
 #
 #Thu Aug 19 16:25:07 EDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR updates the version of Block Store to 16.2.0 to match the version of the [official documentation](https://developers.google.com/identity/blockstore/android).
It also replaces the deprecated  `Task<byte[]> retrieveBytes()` function and adds success and failure listeners to the store, retrieve and delete functions.