### PR TITLE
Use application context for CredentialManager

### DIFF
--- a/CredentialManager/app/src/main/java/com/google/credentialmanager/sample/SignInFragment.kt
+++ b/CredentialManager/app/src/main/java/com/google/credentialmanager/sample/SignInFragment.kt
@@ -62,7 +62,7 @@ class SignInFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        credentialManager = CredentialManager.create(requireActivity())
+        credentialManager = CredentialManager.create(requireContext().applicationContext)
 
         binding.signInWithSavedCredentials.setOnClickListener(signInWithSavedCredentials())
     }

--- a/CredentialManager/app/src/main/java/com/google/credentialmanager/sample/SignUpFragment.kt
+++ b/CredentialManager/app/src/main/java/com/google/credentialmanager/sample/SignUpFragment.kt
@@ -71,7 +71,7 @@ class SignUpFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        credentialManager = CredentialManager.create(requireActivity())
+        credentialManager = CredentialManager.create(requireContext().applicationContext)
 
         binding.signUp.setOnClickListener(signUpWithPasskeys())
         binding.signUpWithPassword.setOnClickListener(signUpWithPassword())


### PR DESCRIPTION
I'm trying to use the CredentialManager in a Hilt + Compose app. I was struggling with how to have an Activity when creating this in Hilt, but I think that isn't actually a requirement, at least from 

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:credentials/credentials/src/main/java/androidx/credentials/CredentialManager.kt;l=87?q=CredentialManager

I don't want to refactor this sample more, but this should allow it to be pulled up to the Application if desired