### PR TITLE
Add check for empty json string when parsing credential descriptors

### DIFF
--- a/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApi.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApi.kt
@@ -424,7 +424,9 @@ class AuthApi @Inject constructor(
                 }
             }
             jsonReader.endObject()
-            jsonArray.put(jsonObject)
+            if(jsonObject.length() != 0) {
+                jsonArray.put(jsonObject)
+            }
         }
         jsonReader.endArray()
         return jsonArray


### PR DESCRIPTION
Should address "No create options" bug when creating passkey