### PR TITLE
Add CI workflows for CredentialManager and WebkitWebView

### DIFF
--- a/.github/workflows/build-credential-manager.yml
+++ b/.github/workflows/build-credential-manager.yml
@@ -1,0 +1,58 @@
+# Workflow name
+name: Build CredentialManager Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Install Android SDK Platform VanillaIceCream
+        run: |
+          echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null
+          echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platforms;android-VanillaIceCream"
+
+      # The sample includes a keystore.properties.template.
+      # For a CI build, we might need to provide a dummy or generated keystore.
+      # For now, let's assume the build works without a specific signing config for debug.
+      # If it requires specific signing for debug, this might fail or need adjustment.
+      - name: Create dummy keystore.properties if not exists
+        run: |
+          if [ ! -f CredentialManager/keystore.properties ]; then
+            echo "Creating dummy keystore.properties for CI build"
+            echo "storeFile=debug.keystore" > CredentialManager/keystore.properties
+            echo "storePassword=android" >> CredentialManager/keystore.properties
+            echo "keyAlias=androiddebugkey" >> CredentialManager/keystore.properties
+            echo "keyPassword=android" >> CredentialManager/keystore.properties
+          fi
+          # Ensure a debug.keystore exists if not provided by checkout
+          if [ ! -f CredentialManager/debug.keystore ]; then
+            echo "Generating dummy debug.keystore for CI build"
+            keytool -genkey -v -keystore CredentialManager/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+          fi
+        working-directory: . # Run from checkout root so CredentialManager/ path is correct
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./CredentialManager
+
+      - name: Build CredentialManager app
+        working-directory: ./CredentialManager
+        run: ./gradlew app:assembleDebug

--- a/.github/workflows/build-webkit-webview.yml
+++ b/.github/workflows/build-webkit-webview.yml
@@ -1,0 +1,48 @@
+# Workflow name
+name: Build WebkitWebView Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Create dummy keystore.properties if not exists
+        run: |
+          if [ ! -f WebView/WebkitWebView/keystore.properties ]; then
+            echo "Creating dummy keystore.properties for CI build"
+            echo "storeFile=debug.keystore" > WebView/WebkitWebView/keystore.properties
+            echo "storePassword=android" >> WebView/WebkitWebView/keystore.properties
+            echo "keyAlias=androiddebugkey" >> WebView/WebkitWebView/keystore.properties
+            echo "keyPassword=android" >> WebView/WebkitWebView/keystore.properties
+          fi
+          if [ ! -f WebView/WebkitWebView/debug.keystore ]; then
+            echo "Generating dummy debug.keystore for CI build"
+            keytool -genkey -v -keystore WebView/WebkitWebView/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+          fi
+        working-directory: . # Run from checkout root
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./WebView/WebkitWebView
+
+      - name: Build WebkitWebView app
+        working-directory: ./WebView/WebkitWebView
+        run: ./gradlew app:assembleDebug


### PR DESCRIPTION
This commit adds GitHub Actions workflows for building the CredentialManager and WebkitWebView samples. These workflows are triggered on push, pull request, and manual dispatch, ensuring continuous integration for these projects.

- Added `build-credential-manager.yml` for the CredentialManager sample.
- Added `build-webkit-webview.yml` for the WebkitWebView sample.

These workflows include steps for:

- Setting up JDK 17
- Setting up Gradle
- Installing Android SDK Platform VanillaIceCream
- Creating dummy keystore if not exists
- Making gradlew executable
- Building the respective Android app