### PR TITLE
Show server errors when response doesn't succeed

### DIFF
--- a/Shrine/app/src/main/java/com/authentication/shrine/api/ApiResult.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/api/ApiResult.kt
@@ -18,7 +18,7 @@ package com.authentication.shrine.api
 /**
  * Represents the result of an API call.
  *
- * This sealed class has three subclasses:
+ * This sealed class has two subclasses:
  * - [Success]: The API call returned successfully with data.
  * - [SignedOutFromServer]: The API call returned unsuccessfully with code 401, and the user should be signed out.
  */

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/RegisterScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/RegisterScreen.kt
@@ -208,6 +208,15 @@ fun RegisterScreen(
                 )
             }
         }
+
+        val snackbarErrorMessage = uiState.errorMessage
+        if (!snackbarErrorMessage.isNullOrBlank()) {
+            LaunchedEffect(uiState) {
+                snackbarHostState.showSnackbar(
+                    message = snackbarErrorMessage,
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Server errors weren't being propagated before, causing the app to directly crash or otherwise show an unhelpful fixed message. This should propagate server errors to the app - note this only handles server errors, i.e. [when the OkHttp response isn't between 200 and 300](https://square.github.io/okhttp/3.x/okhttp/okhttp3/Response.html#isSuccessful--)