### PR TITLE
Add delete passkeys

### DIFF
--- a/Shrine/app/build.gradle.kts
+++ b/Shrine/app/build.gradle.kts
@@ -48,6 +48,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         buildConfigField("String", "API_BASE_URL", "\"https://project-sesame-426206.appspot.com/\"")
+        buildConfigField("String", "API_BASE_DOMAIN", "\"project-sesame-426206.appspot.com\"")
     }
 
     signingConfigs {

--- a/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
@@ -24,13 +24,11 @@ import com.authentication.shrine.model.RegisterResponseRequestBody
 import com.authentication.shrine.model.SignInRequestResponse
 import com.authentication.shrine.model.SignInResponseRequest
 import com.authentication.shrine.model.UsernameRequest
-import okhttp3.HttpUrl
-import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.POST
-import retrofit2.http.Url
+import retrofit2.http.Query
 
 /**
  * Interface defining the API endpoints for authentication and WebAuthn operations.
@@ -151,7 +149,7 @@ interface AuthApiService {
      */
     @POST("webauthn/removeKey")
     suspend fun deletePasskey(
-        @Url url: HttpUrl,
         @Header("Cookie") cookie: String,
+        @Query("credId") credentialId: String,
     ): Response<GenericAuthResponse>
 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
@@ -24,10 +24,13 @@ import com.authentication.shrine.model.RegisterResponseRequestBody
 import com.authentication.shrine.model.SignInRequestResponse
 import com.authentication.shrine.model.SignInResponseRequest
 import com.authentication.shrine.model.UsernameRequest
+import okhttp3.HttpUrl
+import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Url
 
 /**
  * Interface defining the API endpoints for authentication and WebAuthn operations.
@@ -141,5 +144,14 @@ interface AuthApiService {
     @POST("auth/new-user")
     suspend fun registerUsername(
         @Body username: UsernameRequest,
+    ): Response<GenericAuthResponse>
+
+    /**
+     * Deletes a passkey from the authentication server.
+     */
+    @POST("webauthn/removeKey")
+    suspend fun deletePasskey(
+        @Url url: HttpUrl,
+        @Header("Cookie") cookie: String,
     ): Response<GenericAuthResponse>
 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
@@ -488,27 +488,6 @@ class AuthRepository @Inject constructor(
             Log.e(TAG, "Cannot call deletePasskey", e)
         }
         return false
-
-        /*try {
-            val sessionId = dataStore.read(SESSION_ID)
-            if (!sessionId.isNullOrBlank()) {
-                when (val apiResult = authApi.deletePasskey(sessionId, credentialId)) {
-                    is ApiResult.SignedOutFromServer -> {
-                        signOut()
-                    }
-
-                    is ApiResult.Success -> {
-                        dataStore.edit { prefs ->
-                            apiResult.sessionId?.let { prefs[SESSION_ID] = it }
-                        }
-                        return true
-                    }
-                }
-            }
-        } catch (e: ApiException) {
-            Log.e(TAG, "Cannot call deletePasskey", e)
-        }
-        return false*/
     }
 
 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
@@ -505,7 +505,7 @@ class AuthRepository @Inject constructor(
                 }
             }
         } catch (e: ApiException) {
-            Log.e(TAG, "Cannot call deletePasskey")
+            Log.e(TAG, "Cannot call deletePasskey", e)
         }
         return false*/
     }

--- a/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/repository/AuthRepository.kt
@@ -27,6 +27,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.authentication.shrine.R
 import com.authentication.shrine.BuildConfig
 import com.authentication.shrine.api.ApiException
 import com.authentication.shrine.api.AuthApiService

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
@@ -179,8 +179,7 @@ fun PasskeyManagementScreen(
         if(deleteStatus.isNotBlank()) {
             LaunchedEffect(deleteStatus) {
                 snackbarHostState.showSnackbar(
-                    message = deleteStatus,
-                    duration = SnackbarDuration.Indefinite
+                    message = deleteStatus
                 )
             }
         }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -157,29 +156,17 @@ fun PasskeyManagementScreen(
             ShrineLoader()
         }
 
-        val snackbarMessage = stringResource(uiState.messageResourceId)
-        if (snackbarMessage.isNotBlank()) {
-            LaunchedEffect(snackbarMessage) {
-                snackbarHostState.showSnackbar(
-                    message = snackbarMessage,
-                )
-            }
+        val snackbarMessage = when {
+            !uiState.errorMessage.isNullOrBlank() -> uiState.errorMessage
+            uiState.deleteStatus != R.string.empty_string -> stringResource(uiState.deleteStatus)
+            uiState.messageResourceId != R.string.empty_string -> stringResource(uiState.messageResourceId)
+            else -> null
         }
 
-        val snackbarErrorMessage = uiState.errorMessage
-        if (!snackbarErrorMessage.isNullOrBlank()) {
-            LaunchedEffect(snackbarErrorMessage) {
+        if (snackbarMessage != null) {
+            LaunchedEffect(snackbarMessage) {
                 snackbarHostState.showSnackbar(
-                    message = snackbarErrorMessage,
-                )
-            }
-        }
-        
-        val deleteStatus = stringResource(uiState.deleteStatus)
-        if(deleteStatus.isNotBlank()) {
-            LaunchedEffect(deleteStatus) {
-                snackbarHostState.showSnackbar(
-                    message = deleteStatus
+                    message = snackbarMessage
                 )
             }
         }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/SettingsScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/SettingsScreen.kt
@@ -160,18 +160,17 @@ fun SettingsScreen(
             ShrineLoader()
         }
 
-        val snackbarMessage = stringResource(uiState.messageResourceId)
-        if (snackbarMessage.isNotBlank()) {
-            LaunchedEffect(snackbarMessage) {
-                snackbarHostState.showSnackbar(
-                    message = snackbarMessage,
-                )
-            }
+        val snackbarMessage = when {
+            !uiState.errorMessage.isNullOrBlank() -> uiState.errorMessage
+            uiState.messageResourceId != R.string.empty_string -> stringResource(uiState.messageResourceId)
+            else -> null
         }
 
-        if (!uiState.errorMessage.isNullOrBlank()) {
-            LaunchedEffect(uiState) {
-                snackbarHostState.showSnackbar(message = uiState.errorMessage)
+        if (snackbarMessage != null) {
+            LaunchedEffect(snackbarMessage) {
+                snackbarHostState.showSnackbar(
+                    message = snackbarMessage
+                )
             }
         }
     }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/SettingsScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/SettingsScreen.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.authentication.shrine.R
 import com.authentication.shrine.ui.common.ShrineButton
 import com.authentication.shrine.ui.common.ShrineClickableText
@@ -73,6 +76,14 @@ fun SettingsScreen(
     onBackClicked: () -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsState().value
+
+    // Refresh data whenever screen is shown.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(Unit) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.getPasskeysList()
+        }
+    }
 
     SettingsScreen(
         onLearnMoreClicked = onLearnMoreClicked,
@@ -149,10 +160,18 @@ fun SettingsScreen(
             ShrineLoader()
         }
 
-        if (uiState.errorMessage != -1) {
-            val errorMessage = stringResource(uiState.errorMessage)
+        val snackbarMessage = stringResource(uiState.messageResourceId)
+        if (snackbarMessage.isNotBlank()) {
+            LaunchedEffect(snackbarMessage) {
+                snackbarHostState.showSnackbar(
+                    message = snackbarMessage,
+                )
+            }
+        }
+
+        if (!uiState.errorMessage.isNullOrBlank()) {
             LaunchedEffect(uiState) {
-                snackbarHostState.showSnackbar(message = errorMessage)
+                snackbarHostState.showSnackbar(message = uiState.errorMessage)
             }
         }
     }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/navigation/ShrineNavGraph.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/navigation/ShrineNavGraph.kt
@@ -35,7 +35,6 @@ import com.authentication.shrine.ui.RegisterPasswordScreen
 import com.authentication.shrine.ui.RegisterScreen
 import com.authentication.shrine.ui.SettingsScreen
 import com.authentication.shrine.ui.ShrineAppScreen
-import com.authentication.shrine.ui.viewmodel.SettingsViewModel
 
 /**
  * The navigation graph for the Shrine app.
@@ -164,18 +163,12 @@ fun ShrineNavGraph(
         }
 
         composable(route = ShrineAppDestinations.PasskeyManagementTab.name) { backStackEntry ->
-            val viewModel: SettingsViewModel = if (navController.previousBackStackEntry != null) {
-                hiltViewModel(navController.previousBackStackEntry!!)
-            } else {
-                hiltViewModel()
-            }
-
             PasskeyManagementScreen(
                 onLearnMoreClicked = {
                     navController.navigate(ShrineAppDestinations.LearnMore.name)
                 },
                 onBackClicked = { navController.popBackStack() },
-                viewModel = viewModel,
+                viewModel = hiltViewModel(),
             )
         }
 

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authentication.shrine.ui.viewmodel
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.authentication.shrine.R
+import com.authentication.shrine.model.PasskeyCredential
+import com.authentication.shrine.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for user passkey and password registration. Uses [AuthRepository] to interact with the
+ * authentication backend
+ *
+ * @param repository The authentication repository.
+ */
+@HiltViewModel
+class PasskeyManagementViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(PasskeyManagementUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            getPasskeysList()
+        }
+    }
+
+    /**
+     * Makes a request to get a list of passkeys from the server. Very similar to
+     * [com.authentication.shrine.ui.viewmodel.SettingsViewModel.getPasskeysList].
+     */
+    fun getPasskeysList() {
+        _uiState.update {
+            PasskeyManagementUiState(isLoading = true)
+        }
+
+        viewModelScope.launch {
+            try {
+                val data = authRepository.getListOfPasskeys()
+                if (data != null) {
+                    _uiState.update {
+                        PasskeyManagementUiState(
+                            isLoading = false,
+                            userHasPasskeys = data.credentials.isNotEmpty(),
+                            passkeysList = data.credentials,
+                        )
+                    }
+                } else {
+                    _uiState.update {
+                        PasskeyManagementUiState(
+                            messageResourceId = R.string.get_keys_error,
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    PasskeyManagementUiState(
+                        errorMessage = e.message,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Makes a request to delete a passkey from the server. Refreshes the passkey list upon
+     * successful deletion.
+     *
+     * @param credentialId The ID of the passkey to delete.
+     */
+    fun deletePasskey(credentialId: String) {
+        _uiState.update {
+            PasskeyManagementUiState(isLoading = true)
+        }
+
+        viewModelScope.launch {
+            try {
+                if (authRepository.deletePasskey(credentialId)) {
+                    // Refresh passkeys list after deleting a passkey
+                    getPasskeysList()
+                    _uiState.update {
+                        PasskeyManagementUiState(
+                            deleteStatus = R.string.delete_passkey_successful,
+                        )
+                    }
+                } else {
+                    _uiState.update {
+                        PasskeyManagementUiState(
+                            deleteStatus = R.string.delete_passkey_error,
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    PasskeyManagementUiState(
+                        errorMessage = e.message,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Represents the UI state for the passkey management screen.
+ *
+ * @param isLoading Indicates whether a modification operation is in progress.
+ * @param userHasPasskeys Indicates whether the user has passkeys.
+ * @param passkeysList A list of passkeys for the user returned from the server.
+ * @param messageResourceId The resource ID of a message to display to the user.
+ * @param errorMessage An error message returned from the server.
+ * @param deleteStatus The resource ID of a message to display to the user on successful passkey
+ * deletion.
+ */
+data class PasskeyManagementUiState(
+    val isLoading: Boolean = false,
+    val userHasPasskeys: Boolean = true,
+    val passkeysList: List<PasskeyCredential> = listOf(),
+    @StringRes val messageResourceId: Int = R.string.empty_string,
+    val errorMessage: String? = null,
+    @StringRes val deleteStatus: Int = R.string.empty_string,
+)

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
@@ -70,6 +70,7 @@ class PasskeyManagementViewModel @Inject constructor(
                 } else {
                     _uiState.update {
                         it.copy(
+                            isLoading = false,
                             messageResourceId = R.string.get_keys_error,
                         )
                     }
@@ -77,6 +78,7 @@ class PasskeyManagementViewModel @Inject constructor(
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(
+                        isLoading = false,
                         errorMessage = e.message,
                     )
                 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
@@ -53,7 +53,7 @@ class PasskeyManagementViewModel @Inject constructor(
      */
     fun getPasskeysList() {
         _uiState.update {
-            PasskeyManagementUiState(isLoading = true)
+            it.copy(isLoading = true)
         }
 
         viewModelScope.launch {
@@ -61,7 +61,7 @@ class PasskeyManagementViewModel @Inject constructor(
                 val data = authRepository.getListOfPasskeys()
                 if (data != null) {
                     _uiState.update {
-                        PasskeyManagementUiState(
+                        it.copy(
                             isLoading = false,
                             userHasPasskeys = data.credentials.isNotEmpty(),
                             passkeysList = data.credentials,
@@ -69,14 +69,14 @@ class PasskeyManagementViewModel @Inject constructor(
                     }
                 } else {
                     _uiState.update {
-                        PasskeyManagementUiState(
+                        it.copy(
                             messageResourceId = R.string.get_keys_error,
                         )
                     }
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    PasskeyManagementUiState(
+                    it.copy(
                         errorMessage = e.message,
                     )
                 }
@@ -92,29 +92,34 @@ class PasskeyManagementViewModel @Inject constructor(
      */
     fun deletePasskey(credentialId: String) {
         _uiState.update {
-            PasskeyManagementUiState(isLoading = true)
+            it.copy(isLoading = true)
         }
 
         viewModelScope.launch {
             try {
                 if (authRepository.deletePasskey(credentialId)) {
                     // Refresh passkeys list after deleting a passkey
-                    getPasskeysList()
+                    val data = authRepository.getListOfPasskeys()
                     _uiState.update {
-                        PasskeyManagementUiState(
-                            deleteStatus = R.string.delete_passkey_successful,
+                        it.copy(
+                            isLoading = false,
+                            userHasPasskeys = data?.credentials?.isNotEmpty() ?: false,
+                            passkeysList = data?.credentials ?: emptyList(),
+                            deleteStatus = R.string.delete_passkey_successful
                         )
                     }
                 } else {
                     _uiState.update {
-                        PasskeyManagementUiState(
+                        it.copy(
+                            isLoading = false,
                             deleteStatus = R.string.delete_passkey_error,
                         )
                     }
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    PasskeyManagementUiState(
+                    it.copy(
+                        isLoading = false,
                         errorMessage = e.message,
                     )
                 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
@@ -66,7 +66,7 @@ class SettingsViewModel @Inject constructor(
                 val data = authRepository.getListOfPasskeys()
                 if (data != null) {
                     _uiState.update {
-                        SettingsUiState(
+                        it.copy(
                             isLoading = false,
                             userHasPasskeys = data.credentials.isNotEmpty(),
                             username = authRepository.getUsername(),
@@ -75,7 +75,7 @@ class SettingsViewModel @Inject constructor(
                     }
                 } else {
                     _uiState.update {
-                        SettingsUiState(
+                        it.copy(
                             isLoading = false,
                             messageResourceId = R.string.get_keys_error,
                         )
@@ -83,7 +83,7 @@ class SettingsViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    SettingsUiState(
+                    it.copy(
                         isLoading = false,
                         errorMessage = e.message,
                     )

--- a/Shrine/app/src/main/res/values/strings.xml
+++ b/Shrine/app/src/main/res/values/strings.xml
@@ -90,6 +90,6 @@
     <string name="other_options">Other options</string>
     <string name="register_password">Register with password</string>
     <string name="delete_passkey_successful">Passkey deleted successfully.</string>
-    <string name="delete_passkey_error">"Error in deleting passkey, please check logs"</string>
+    <string name="delete_passkey_error">Error in deleting passkey, please check logs</string>
     <string name="cannot_call_delete_passkey">Cannot call deletePasskey</string>
 </resources>

--- a/Shrine/app/src/main/res/values/strings.xml
+++ b/Shrine/app/src/main/res/values/strings.xml
@@ -83,10 +83,12 @@
     <string name="learn_more_about_passkeys">Learn more about passkeys</string>
     <string name="credential_provider_logo">Credential Provider Logo</string>
     <string name="created">Created: %1$s</string>
-    <string name="get_keys_error">Some error occurred while getting the list of passkeys</string>
+    <string name="get_keys_error">Some error occurred while getting the list of passkeys. Please log out and try again.</string>
     <string name="delete">Delete</string>
     <string name="back_arrow_on_toolbar">Back Arrow on Toolbar</string>
     <string name="sign_up_with_password">Sign up with password</string>
     <string name="other_options">Other options</string>
     <string name="register_password">Register with password</string>
+    <string name="delete_passkey_successful">Passkey deleted successfully.</string>
+    <string name="delete_passkey_error">"Error in deleting passkey, please check logs"</string>
 </resources>

--- a/Shrine/app/src/main/res/values/strings.xml
+++ b/Shrine/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="register_password">Register with password</string>
     <string name="delete_passkey_successful">Passkey deleted successfully.</string>
     <string name="delete_passkey_error">"Error in deleting passkey, please check logs"</string>
+    <string name="cannot_call_delete_passkey">Cannot call deletePasskey</string>
 </resources>


### PR DESCRIPTION
Add delete passkeys functionality and splits passkey management to a separate view model. This also removes checking for session ID in getKeys and deletePasskeys since it is are not returned with the cookie for these functions.