### PR TITLE
Enable restore credentials signal to server and app settings management

### DIFF
--- a/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/api/AuthApiService.kt
@@ -83,6 +83,8 @@ interface AuthApiService {
      * to complete the passkey registration.
      *
      * @param cookie The session cookie for authentication.
+     * @param type The type of credential. Only used to specify Restore Credential passkeys to the
+     * server.
      * @param requestBody The request body containing the client's attestation response
      *                    to the registration challenge.
      * @return A Retrofit {@link Response} wrapping a {@link GenericAuthResponse},
@@ -91,6 +93,7 @@ interface AuthApiService {
     @POST("webauthn/registerResponse")
     suspend fun registerResponse(
         @Header("Cookie") cookie: String,
+        @Query("type") type: String?,
         @Body requestBody: RegisterResponseRequestBody,
     ): Response<GenericAuthResponse>
 

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/PasskeyManagementScreen.kt
@@ -80,16 +80,20 @@ fun PasskeyManagementScreen(
     credentialManagerUtils: CredentialManagerUtils,
 ) {
     val uiState = viewModel.uiState.collectAsState().value
-    val onDeleteClicked = { credentialId: String -> viewModel.deletePasskey(credentialId) }
+    // remember is added to callbacks so LazyColumn doesn't recompose when each one loads
+    val onDeleteClicked =
+        remember { { credentialId: String -> viewModel.deletePasskey(credentialId) } }
     val context = LocalContext.current
-    val onCreatePasskeyClicked = {
-        viewModel.createPasskey(
-            { data ->
-                credentialManagerUtils.createPasskey(
-                    requestResult = data,
-                    context = context,
-                )
-            })
+    val onCreatePasskeyClicked = remember {
+        {
+            viewModel.createPasskey(
+                { data ->
+                    credentialManagerUtils.createPasskey(
+                        requestResult = data,
+                        context = context,
+                    )
+                })
+        }
     }
 
     PasskeyManagementScreen(

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/HomeViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/HomeViewModel.kt
@@ -42,8 +42,9 @@ class HomeViewModel @Inject constructor(
         deleteRestoreKey: suspend () -> Unit,
     ) {
         viewModelScope.launch {
-            repository.signOut()
             deleteRestoreKey()
+            repository.deleteRestoreKeyFromServer()
+            repository.signOut()
         }
     }
 }

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/PasskeyManagementViewModel.kt
@@ -24,6 +24,7 @@ import com.authentication.shrine.GenericCredentialManagerResponse
 import com.authentication.shrine.R
 import com.authentication.shrine.model.PasskeyCredential
 import com.authentication.shrine.repository.AuthRepository
+import com.authentication.shrine.repository.AuthRepository.Companion.RESTORE_CREDENTIAL_AAGUID
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -251,10 +252,6 @@ class PasskeyManagementViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    companion object {
-        const val RESTORE_CREDENTIAL_AAGUID = "restore-credential"
     }
 }
 

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.authentication.shrine.R
 import com.authentication.shrine.model.PasskeyCredential
 import com.authentication.shrine.repository.AuthRepository
-import com.authentication.shrine.ui.viewmodel.PasskeyManagementViewModel.Companion.RESTORE_CREDENTIAL_AAGUID
+import com.authentication.shrine.repository.AuthRepository.Companion.RESTORE_CREDENTIAL_AAGUID
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
+++ b/Shrine/app/src/main/java/com/authentication/shrine/ui/viewmodel/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.authentication.shrine.R
 import com.authentication.shrine.model.PasskeyCredential
 import com.authentication.shrine.repository.AuthRepository
+import com.authentication.shrine.ui.viewmodel.PasskeyManagementViewModel.Companion.RESTORE_CREDENTIAL_AAGUID
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -65,12 +66,14 @@ class SettingsViewModel @Inject constructor(
             try {
                 val data = authRepository.getListOfPasskeys()
                 if (data != null) {
+                    val filteredPasskeysList =
+                        data.credentials.filter({ passkey -> passkey.aaguid != RESTORE_CREDENTIAL_AAGUID })
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            userHasPasskeys = data.credentials.isNotEmpty(),
+                            userHasPasskeys = filteredPasskeysList.isNotEmpty(),
                             username = authRepository.getUsername(),
-                            passkeysList = data.credentials,
+                            passkeysList = filteredPasskeysList,
                         )
                     }
                 } else {


### PR DESCRIPTION
Signify to the server when Restore Credential passkeys are created. Don't show them in settins or passkey management UI, and delete from the server when the user signs out.