### PR TITLE
Rename filters in issuance matcher for better readability

### DIFF
--- a/CredentialProvider/wasm/matcher-rs/src/issuance.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/issuance.rs
@@ -248,11 +248,11 @@ mod test {
         "filter": {
           "And": {
             "filters": [{
-              "AllowsConfigurationIds": {
+              "AllowedConfigurationIds": {
                 "configuration_ids": ["US_SOCIAL_SECURITY_NUMBER", "EU_AGE"]
               }
             }, {
-              "AllowsIssuers": {
+              "AllowedIssuers": {
                 "issuers": ["ccb", "https://issuer.my"]
               }
             }]
@@ -302,7 +302,7 @@ mod test {
         "title": "TTTT",
         "subtitle": "SSSSS",
         "icon": [0, 0],
-        "filter": {"Unit": {}}"#,
+        "filter": {"Pass": {}}"#,
             icon: Vec::new(),
             added_entries: Vec::new(),
         };
@@ -349,7 +349,7 @@ mod test {
     "And": {
       "filters": [
         {
-          "AllowsConfigurationIds": {
+          "AllowedConfigurationIds": {
             "configuration_ids": [
               "US_SOCIAL_SECURITY_NUMBER",
               "EU_AGE"
@@ -357,7 +357,7 @@ mod test {
           }
         },
         {
-          "AllowsIssuers": {
+          "AllowedIssuers": {
             "issuers": [
               "ccb",
               "https://issuer.my"
@@ -427,7 +427,7 @@ mod test {
     "Or": {
       "filters": [
         {
-          "AllowsConfigurationIds": {
+          "AllowedConfigurationIds": {
             "configuration_ids": [
               "US_SOCIAL_SECURITY_NUMBER",
               "EU_AGE"
@@ -435,14 +435,14 @@ mod test {
           }
         },
         {
-          "AllowsIssuers": {
+          "AllowedIssuers": {
             "issuers": [
               "ccb"
             ]
           }
         },
         {
-          "SupportsMdocDoctype": {
+          "AllowedMdocDoctypes": {
             "doctypes": [
               "org.iso.18013.5.1.mDL"
             ]

--- a/CredentialProvider/wasm/matcher-rs/src/issuance_matcher.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/issuance_matcher.rs
@@ -6,7 +6,7 @@ use crate::openid4vci::RegularizedOpenId4VciRequestData;
 
 #[derive(DeJson, Debug)]
 pub enum OpenId4VciFilter {
-    Unit {}, // A placeholder that always matches
+    Pass {}, // A placeholder that always matches
     And {
         filters: Vec<OpenId4VciFilter>,
     },
@@ -16,10 +16,10 @@ pub enum OpenId4VciFilter {
     Not {
         filter: Box<OpenId4VciFilter>,
     },
-    AllowsIssuers {
+    AllowedIssuers {
         issuers: DeterministicSet<String>,
     },
-    AllowsConfigurationIds {
+    AllowedConfigurationIds {
         configuration_ids: DeterministicSet<String>,
     },
     SupportsAuthCodeFlow {},
@@ -30,25 +30,25 @@ pub enum OpenId4VciFilter {
     RequiresBatchIssuance {
         min_batch_size: u32,
     },
-    SupportsMdocDoctype {
+    AllowedMdocDoctypes {
         doctypes: DeterministicSet<String>,
     },
-    SupportsSdJwtVct {
+    AllowedSdJwtVcts {
         vcts: DeterministicSet<String>,
     },
 }
 
 impl Default for OpenId4VciFilter {
     fn default() -> Self {
-        Self::Unit {}
+        Self::Pass {}
     }
 }
 
 impl OpenId4VciFilter {
     pub fn matches(&self, request: &RegularizedOpenId4VciRequestData) -> bool {
         let matched = match &self {
-            Self::Unit {} => {
-                log::trace!("Filter Unit matched");
+            Self::Pass {} => {
+                log::trace!("Filter Pass matched");
                 true
             }
             Self::And { filters } => {
@@ -66,21 +66,21 @@ impl OpenId4VciFilter {
                 log::trace!("Filter Not matched: {}", res);
                 res
             }
-            Self::AllowsIssuers { issuers } => {
+            Self::AllowedIssuers { issuers } => {
                 let res = issuers.contains(request.credential_issuer);
                 log::trace!(
-                    "Filter AllowsIssuers (issuer={}) matched: {}",
+                    "Filter AllowedIssuers (issuer={}) matched: {}",
                     request.credential_issuer,
                     res
                 );
                 res
             }
-            Self::AllowsConfigurationIds { configuration_ids } => {
+            Self::AllowedConfigurationIds { configuration_ids } => {
                 let res = request
                     .credential_configuration_ids
                     .iter()
                     .any(|id| configuration_ids.contains(id));
-                log::trace!("Filter AllowsConfigurationIds matched: {}", res);
+                log::trace!("Filter AllowedConfigurationIds matched: {}", res);
                 res
             }
             Self::SupportsAuthCodeFlow {} => {
@@ -129,20 +129,20 @@ impl OpenId4VciFilter {
                 );
                 res
             }
-            Self::SupportsMdocDoctype { doctypes } => {
+            Self::AllowedMdocDoctypes { doctypes } => {
                 let res = request
                     .credential_configurations
                     .iter()
                     .any(|c| doctypes.contains(&c.doctype));
-                log::trace!("Filter SupportsMdocDoctype matched: {}", res);
+                log::trace!("Filter AllowedMdocDoctypes matched: {}", res);
                 res
             }
-            Self::SupportsSdJwtVct { vcts } => {
+            Self::AllowedSdJwtVcts { vcts } => {
                 let res = request
                     .credential_configurations
                     .iter()
                     .any(|c| vcts.contains(&c.vct));
-                log::trace!("Filter SupportsSdJwtVct matched: {}", res);
+                log::trace!("Filter AllowedSdJwtVcts matched: {}", res);
                 res
             }
         };


### PR DESCRIPTION
Rename the following filters in OpenId4VciFilter:
- Unit -> Pass
- AllowsIssuers -> AllowedIssuers
- AllowsConfigurationIds -> AllowedConfigurationIds
- SupportsMdocDoctype -> AllowedMdocDoctypes
- SupportsSdJwtVct -> AllowedSdJwtVcts

Remove several filters who semantics need more thoughts.

TAG=agy
CONV=99341d70-01c8-4512-b72c-302e7d7eaccf