### PR TITLE
Add metadata parameter to AddIssuanceEntry

### DIFF
--- a/CredentialProvider/wasm/matcher-rs/src/bindings.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/bindings.rs
@@ -91,6 +91,7 @@ unsafe extern "C" {
         title: *const c_char,
         subtitle: *const c_char,
         explainer: *const c_char,
+        metadata: *const c_char,
     );
     pub fn AddFieldForStringIdEntry(
         cred_id: *const c_char,

--- a/CredentialProvider/wasm/matcher-rs/src/credman.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/credman.rs
@@ -26,6 +26,7 @@ pub trait CredmanApi {
         title: &str,
         subtitle: &str,
         explainer: &str,
+        metadata: &str,
     );
     fn add_entry_set(&mut self, set_id: &str, set_length: i32);
     fn add_entry_to_set(
@@ -172,6 +173,7 @@ impl CredmanApi for CredmanApiImpl {
         title: &str,
         subtitle: &str,
         explainer: &str,
+        metadata: &str,
     ) {
         let entry_id_c = CString::new(entry_id).unwrap();
         let title_c = if title.is_empty() {
@@ -189,6 +191,11 @@ impl CredmanApi for CredmanApiImpl {
         } else {
             Some(CString::new(explainer).unwrap())
         };
+        let metadata_c = if metadata.is_empty() {
+            None
+        } else {
+            Some(CString::new(metadata).unwrap())
+        };
 
         let icon_bytes = if icon.is_empty() {
             std::ptr::null()
@@ -205,6 +212,7 @@ impl CredmanApi for CredmanApiImpl {
                 title_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
                 subtitle_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
                 explainer_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
+                metadata_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
             );
         }
     }

--- a/CredentialProvider/wasm/matcher-rs/src/issuance.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/issuance.rs
@@ -4,7 +4,12 @@ use crate::{
     openid4vci::{DigitalCredentialCreationRequest, RegularizedOpenId4VciRequestData},
 };
 
-use nanoserde::DeJson;
+use nanoserde::{DeJson, SerJson};
+
+#[derive(SerJson)]
+struct IssuanceMetadata {
+    eidx: usize,
+}
 
 const ALLOWED_PROTOCOLS: [&str; 4] = [
     "openid4vci-1.0",
@@ -74,12 +79,14 @@ pub fn issuance_main(credman: &mut impl CredmanApi) -> Result<(), Box<dyn std::e
                     let icon = &matcher_data_buffer[entry.icon.0..entry.icon.1];
                     if version >= 9 {
                         log::debug!("Adding issuance entry (v>=9): {}", entry_id);
+                        let metadata = SerJson::serialize_json(&IssuanceMetadata { eidx: index });
                         credman.add_issuance_entry(
                             &entry_id,
                             icon,
                             &entry.title,
                             &entry.subtitle,
                             "",
+                            &metadata,
                         );
                     } else {
                         log::debug!("Adding string ID entry (v<9): {}", entry_id);
@@ -124,6 +131,7 @@ mod test {
         disclaimer: Option<CString>,
         warning: Option<CString>,
         explainer: Option<CString>,
+        metadata: Option<CString>,
         call_type: CallType,
     }
 
@@ -188,6 +196,7 @@ mod test {
                     Some(CString::new(warning).unwrap())
                 },
                 explainer: None,
+                metadata: None,
                 call_type: CallType::StringId,
             });
         }
@@ -198,6 +207,7 @@ mod test {
             title: &str,
             subtitle: &str,
             explainer: &str,
+            metadata: &str,
         ) {
             self.added_entries.push(AddedEntry {
                 entry_id: CString::new(entry_id).unwrap(),
@@ -222,6 +232,11 @@ mod test {
                     None
                 } else {
                     Some(CString::new(explainer).unwrap())
+                },
+                metadata: if metadata.is_empty() {
+                    None
+                } else {
+                    Some(CString::new(metadata).unwrap())
                 },
                 call_type: CallType::Issuance,
             });
@@ -709,6 +724,7 @@ mod test {
         assert!(entry.icon.is_none());
         assert_eq!(entry.call_type, CallType::Issuance);
         assert!(entry.explainer.is_none());
+        assert_eq!(entry.metadata.as_ref().unwrap(), c"{\"eidx\":0}");
     }
 
     #[test]
@@ -763,7 +779,9 @@ mod test {
         assert_eq!(credman.added_entries.len(), 2);
         assert_eq!(credman.added_entries[0].entry_id, c"C_0");
         assert_eq!(credman.added_entries[0].title.as_ref().unwrap(), c"TTTT1");
+        assert_eq!(credman.added_entries[0].metadata.as_ref().unwrap(), c"{\"eidx\":0}");
         assert_eq!(credman.added_entries[1].entry_id, c"C_1");
         assert_eq!(credman.added_entries[1].title.as_ref().unwrap(), c"TTTT2");
+        assert_eq!(credman.added_entries[1].metadata.as_ref().unwrap(), c"{\"eidx\":1}");
     }
 }

--- a/CredentialProvider/wasm/matcher-rs/src/reporter.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/reporter.rs
@@ -438,6 +438,7 @@ mod tests {
             _title: &str,
             _subtitle: &str,
             _explainer: &str,
+            _metadata: &str,
         ) {
         }
         fn add_entry_set(&mut self, set_id: &str, length: i32) {

--- a/CredentialProvider/wasm/matcher-rs/src/test_utils.rs
+++ b/CredentialProvider/wasm/matcher-rs/src/test_utils.rs
@@ -49,6 +49,7 @@ pub struct AddedEntry {
     pub disclaimer: String,
     pub warning: String,
     pub explainer: String,
+    pub metadata: String,
 }
 
 #[derive(SerJson, DeJson, PartialEq, Debug, Clone)]
@@ -118,6 +119,7 @@ impl CredmanApi for FakeCredman {
             disclaimer: disclaimer.to_string(),
             warning: warning.to_string(),
             explainer: String::new(),
+            metadata: String::new(),
         });
     }
     fn add_issuance_entry(
@@ -127,6 +129,7 @@ impl CredmanApi for FakeCredman {
         title: &str,
         subtitle: &str,
         explainer: &str,
+        metadata: &str,
     ) {
         self.added_entries.push(AddedEntry {
             entry_id: id.to_string(),
@@ -136,6 +139,7 @@ impl CredmanApi for FakeCredman {
             disclaimer: String::new(),
             warning: String::new(),
             explainer: explainer.to_string(),
+            metadata: metadata.to_string(),
         });
     }
     fn add_entry_set(&mut self, set_id: &str, set_length: i32) {


### PR DESCRIPTION
Updated AddIssuanceEntry WASM binding to accept a metadata parameter. Updated CredmanApi trait and implementations (including mocks and test helpers) to support this parameter. On match, issuance_main now passes a serialized JSON string {"eidx": index} as metadata to AddIssuanceEntry, using a new IssuanceMetadata struct and SerJson for serialization. Updated tests to verify the metadata is correctly passed.

TAG=agy

CONV=6222f947-d807-4f7a-8223-5f30b7376340